### PR TITLE
Potential fix for code scanning alert no. 13: Uncontrolled data used in path expression

### DIFF
--- a/controllers/testcase.js
+++ b/controllers/testcase.js
@@ -76,7 +76,11 @@ const fetch = async (ctx) => {
   }
 
   const testDir = path.resolve(__dirname, `../data/${pid}`)
-  if (!fse.existsSync(path.resolve(testDir, `${uuid}.${type}`))) {
+  const filePath = path.resolve(testDir, `${uuid}.${type}`)
+  if (!filePath.startsWith(testDir)) {
+    ctx.throw(400, 'Invalid file path')
+  }
+  if (!fse.existsSync(filePath)) {
     ctx.throw(400, 'No such a testcase')
   }
   ctx.type = 'text/plain; charset=utf-8'

--- a/controllers/testcase.js
+++ b/controllers/testcase.js
@@ -76,7 +76,7 @@ const fetch = async (ctx) => {
   }
 
   const testDir = path.resolve(__dirname, `../data/${pid}`)
-  const filePath = path.resolve(testDir, `${uuid}.${type}`)
+  const filePath = path.normalize(path.resolve(testDir, `${uuid}.${type}`))
   if (!filePath.startsWith(testDir)) {
     ctx.throw(400, 'Invalid file path')
   }


### PR DESCRIPTION
Potential fix for [https://github.com/net-escape/ptoj-backend/security/code-scanning/13](https://github.com/net-escape/ptoj-backend/security/code-scanning/13)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root directory. We can achieve this by normalizing the path using `path.resolve` and then checking that the normalized path starts with the root directory. This will prevent any path traversal attacks.

1. Normalize the constructed file path using `path.resolve`.
2. Check that the normalized path starts with the root directory.
3. If the check fails, throw an error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
